### PR TITLE
Implement Telegram-controlled Bybit P2P bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# test_bybit_bot
-automate p2p trading on Bybit
+# Bybit P2P Trading Bot
+
+This project provides a small Telegram controlled bot to automate basic P2P trading tasks on Bybit.  
+The bot loads a YAML configuration file and starts periodic loops that update P2P ads and interact with new orders.
+
+## Features
+- Load `config.yaml` via Telegram document message.
+- Periodic update loop for SELL and BUY ads.
+- One‑time greeting in new order chats.
+- One‑time automatic mark as paid for BUY orders.
+- Placeholder functions for pricing strategies.
+
+## Usage
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export your Telegram bot token
+   ```bash
+   export TELEGRAM_TOKEN=123:ABC
+   ```
+3. Run the bot
+   ```bash
+   python -m bybit_bot.bot
+   ```
+
+Edit `config.yaml` to set Bybit API credentials and ad parameters.  
+Send the file to your bot to start trading.

--- a/bybit_bot/bot.py
+++ b/bybit_bot/bot.py
@@ -1,0 +1,161 @@
+import asyncio
+import logging
+from pathlib import Path
+from typing import Dict, Set
+
+from telegram import Update, Document
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    MessageHandler,
+    ContextTypes,
+    filters,
+)
+
+from .config_loader import load_config, Config, AdConfig
+from .bybit_client import BybitClient
+from .price_strategy import (
+    calculate_sell_price,
+    calculate_buy_price,
+    calculate_buy_quantity,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = Path("config.yaml")
+
+class TradingBot:
+    def __init__(self, telegram_token: str):
+        self.application = ApplicationBuilder().token(telegram_token).build()
+        self.config: Config | None = None
+        self.bybit: BybitClient | None = None
+        self.seen_orders: Set[str] = set()
+        self.paid_orders: Set[str] = set()
+        self._tasks: Set[asyncio.Task] = set()
+
+        self.application.add_handler(CommandHandler("start", self.start))
+        self.application.add_handler(MessageHandler(filters.Document.ALL, self.load_config_file))
+
+    async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        await update.message.reply_text("Send config.yaml as a document to load configuration")
+
+    async def load_config_file(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        document: Document = update.message.document
+        if not document.file_name.endswith(".yaml"):
+            await update.message.reply_text("Please send a .yaml configuration file")
+            return
+        file_path = CONFIG_PATH
+        await document.get_file().download_to_drive(custom_path=str(file_path))
+        self.config = load_config(file_path)
+        self.bybit = BybitClient(
+            api_key=self.config.api_key,
+            api_secret=self.config.api_secret,
+            testnet=self.config.testnet,
+        )
+        await update.message.reply_text("Configuration loaded. Starting loops...")
+        self.start_loops()
+
+    def start_loops(self):
+        if not self.config or not self.bybit:
+            return
+        task = self.application.create_task(self.loop())
+        self._tasks.add(task)
+
+    async def loop(self):
+        assert self.config and self.bybit
+        interval = self.config.update_interval
+        while True:
+            try:
+                await self.update_sell_ads()
+                await self.update_buy_ads()
+                await self.process_orders()
+            except Exception as e:
+                logger.exception("Error in main loop: %s", e)
+            await asyncio.sleep(interval)
+
+    async def update_sell_ads(self):
+        assert self.bybit and self.config
+        for ad_conf in self.config.ads:
+            if ad_conf.type.upper() != "SELL":
+                continue
+            ad = self.bybit.find_ad_by_tag(1, ad_conf.tag)
+            if not ad:
+                continue
+            price = ad_conf.fixed_price
+            if price is None:
+                price = calculate_sell_price(ad_conf, 0)
+            quantity = ad_conf.balance
+            if isinstance(quantity, str) and quantity == "max":
+                balance = self.bybit.get_balance()
+                quantity = balance.get("availableBalance")
+            self.bybit.update_ad(
+                id=ad.get("itemId") or ad.get("id"),
+                priceType=0,
+                price=price,
+                minAmount=ad_conf.min_amount,
+                maxAmount=ad_conf.max_amount,
+                paymentIds=ad_conf.payment_ids,
+                quantity=quantity,
+                remark=ad_conf.remark or ad.get("remark"),
+                actionType="MODIFY",
+            )
+
+    async def update_buy_ads(self):
+        assert self.bybit and self.config
+        for ad_conf in self.config.ads:
+            if ad_conf.type.upper() != "BUY":
+                continue
+            ad = self.bybit.find_ad_by_tag(0, ad_conf.tag)
+            if not ad:
+                continue
+            price = ad_conf.fixed_price
+            if price is None:
+                price = calculate_buy_price(ad_conf, 0)
+            quantity = ad_conf.quantity
+            if quantity is None:
+                quantity = calculate_buy_quantity(ad_conf, 0)
+            self.bybit.update_ad(
+                id=ad.get("itemId") or ad.get("id"),
+                priceType=0,
+                price=price,
+                minAmount=ad_conf.min_amount,
+                maxAmount=ad_conf.max_amount,
+                paymentIds=ad_conf.payment_ids,
+                quantity=quantity,
+                remark=ad_conf.remark or ad.get("remark"),
+                actionType="MODIFY",
+            )
+
+    async def process_orders(self):
+        assert self.bybit
+        for order in self.bybit.get_pending_orders():
+            order_id = str(order.get("orderId") or order.get("id"))
+            side = order.get("side")
+            if order_id not in self.seen_orders:
+                self.bybit.send_chat_message(order_id, "\U0001F44B\U0001F440")
+                self.seen_orders.add(order_id)
+            if side == 0 and order_id not in self.paid_orders:
+                details = self.bybit.get_order_details(order_id)
+                terms = details.get("paymentTermList", [{}])[0]
+                payment_type = terms.get("paymentType")
+                payment_id = terms.get("id")
+                if payment_type and payment_id:
+                    self.bybit.mark_as_paid(order_id, payment_type, payment_id)
+                    self.bybit.send_chat_message(order_id, "pls wait, I'm paying")
+                self.paid_orders.add(order_id)
+
+    def run(self):
+        self.application.run_polling()
+
+
+def main():
+    import os
+    token = os.getenv("TELEGRAM_TOKEN", "")
+    if not token:
+        raise RuntimeError("TELEGRAM_TOKEN env var not set")
+    bot = TradingBot(token)
+    bot.run()
+
+if __name__ == "__main__":
+    main()

--- a/bybit_bot/bybit_client.py
+++ b/bybit_bot/bybit_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+from typing import List, Optional, Dict, Any
+from bybit_p2p import P2P
+
+class BybitClient:
+    """Wrapper around bybit_p2p.P2P to simplify common operations."""
+
+    def __init__(self, *, api_key: str, api_secret: str, testnet: bool = False):
+        self.client = P2P(testnet=testnet, api_key=api_key, api_secret=api_secret)
+
+    def get_active_ads(self, side: int) -> List[Dict[str, Any]]:
+        """Return list of online ads for the account."""
+        resp = self.client.get_ads_list(side=side, status=2, page=1, size=50)
+        return resp.get("result", {}).get("items", [])
+
+    def find_ad_by_tag(self, side: int, tag: str) -> Optional[Dict[str, Any]]:
+        for ad in self.get_active_ads(side):
+            remark = ad.get("remark", "") or ""
+            if remark.startswith(tag):
+                return ad
+        return None
+
+    def update_ad(self, **params):
+        return self.client.update_ad(**params)
+
+    def get_pending_orders(self) -> List[Dict[str, Any]]:
+        resp = self.client.get_pending_orders(page=1, size=50)
+        return resp.get("result", {}).get("items", [])
+
+    def get_order_details(self, order_id: str) -> Dict[str, Any]:
+        resp = self.client.get_order_details(orderId=order_id)
+        return resp.get("result", {})
+
+    def send_chat_message(self, order_id: str, message: str):
+        from uuid import uuid4
+        self.client.send_chat_message(
+            orderId=order_id,
+            message=message,
+            contentType="str",
+            msgUuid=str(uuid4()),
+        )
+
+    def mark_as_paid(self, order_id: str, payment_type: str, payment_id: str):
+        self.client.mark_as_paid(
+            orderId=order_id,
+            paymentType=payment_type,
+            paymentId=payment_id,
+        )
+
+    def get_balance(self, account_type: str = "UNIFIED") -> Dict[str, Any]:
+        resp = self.client.get_current_balance(accountType=account_type)
+        return resp.get("result", {})

--- a/bybit_bot/config_loader.py
+++ b/bybit_bot/config_loader.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, Union
+import yaml
+
+@dataclass
+class AdConfig:
+    tag: str
+    type: str  # SELL or BUY
+    fixed_price: Optional[float] = None
+    balance: Optional[Union[str, float]] = None
+    quantity: Optional[float] = None
+    min_amount: Optional[float] = None
+    max_amount: Optional[float] = None
+    payment_ids: List[str] = field(default_factory=list)
+    remark: str = ""
+
+@dataclass
+class Config:
+    api_key: str
+    api_secret: str
+    testnet: bool = False
+    update_interval: int = 60
+    ads: List[AdConfig] = field(default_factory=list)
+
+def load_config(path: str) -> Config:
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    ads = [AdConfig(**ad) for ad in data.get("ads", [])]
+    return Config(
+        api_key=data.get("api_key", ""),
+        api_secret=data.get("api_secret", ""),
+        testnet=data.get("testnet", False),
+        update_interval=data.get("update_interval", 60),
+        ads=ads,
+    )

--- a/bybit_bot/price_strategy.py
+++ b/bybit_bot/price_strategy.py
@@ -1,0 +1,13 @@
+"""Placeholders for pricing and quantity strategies."""
+
+def calculate_sell_price(ad, market_price):
+    """Return price for SELL ad. Placeholder for custom logic."""
+    return market_price
+
+def calculate_buy_price(ad, market_price):
+    """Return price for BUY ad. Placeholder for custom logic."""
+    return market_price
+
+def calculate_buy_quantity(ad, available_balance):
+    """Return quantity for BUY ad. Placeholder for custom logic."""
+    return ad.quantity or 0

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+# Example configuration
+api_key: "YOUR_API_KEY"
+api_secret: "YOUR_API_SECRET"
+testnet: true
+update_interval: 60
+ads:
+  - tag: "#S1"
+    type: SELL
+    fixed_price: 100.0
+    balance: "max"
+    min_amount: 10
+    max_amount: 1000
+    payment_ids: ["123"]
+    remark: "#S1 Sell USDT"
+  - tag: "#B1"
+    type: BUY
+    fixed_price: 90.0
+    quantity: 50
+    min_amount: 10
+    max_amount: 1000
+    payment_ids: ["123"]
+    remark: "#B1 Buy USDT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+python-telegram-bot>=22.0
+pyyaml
+bybit-p2p
+requests
+requests-toolbelt
+pycryptodome


### PR DESCRIPTION
## Summary
- create a Python package `bybit_bot` implementing a basic trading bot
- load configuration from a YAML file via Telegram
- connect to Bybit using the official `bybit_p2p` library
- start periodic loops to update ads and process orders
- provide placeholders for pricing strategies
- add example `config.yaml` and usage instructions

## Testing
- `python -m py_compile bybit_bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6844379dd7cc8328a6a65e507b36892e